### PR TITLE
Add further documentation for the db.insert function

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,26 @@ alice.insert({ crazy: true }, 'rabbit', function(err, body) {
 });
 ```
 
+The `insert` function can also be used with the method signature `db.insert(doc,[callback])`, where the `doc` contains the `_id` field e.g.
+
+~~~ js
+var alice = cloudant.use('alice')
+alice.insert({ _id: 'myid', crazy: true }, function(err, body) {
+  if (!err)
+    console.log(body)
+})
+~~~
+
+and also used to update an existing document, by including the `_rev` token in the document being saved:
+
+~~~ js
+var alice = cloudant.use('alice')
+alice.insert({ _id: 'myid', _rev: '1-23202479633c2b380f79507a776743d5', crazy: false }, function(err, body) {
+  if (!err)
+    console.log(body)
+})
+~~~
+
 ### db.destroy(docname, rev, [callback])
 
 removes revision `rev` of `docname` from couchdb.


### PR DESCRIPTION
The db.insert function can be used to both create and update documents. This wasn't clear from the the README and we had more than one issue raise about it on our Cloudant fork of the project. This commit shows using the function with one parameter and a callaback, and its use to update existing documents.